### PR TITLE
More test coverage + Fix C_GetAttributeValue to set arg length when arg handle is NULL

### DIFF
--- a/source/portable/mbedtls/iot_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/iot_pkcs11_mbedtls.c
@@ -2849,10 +2849,11 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                     break;
 
                 case CKA_EC_PARAMS:
-
-                    pTemplate[ iAttrib ].ulValueLen = sizeof( ucP256Oid );
-
-                    if( pTemplate[ iAttrib ].pValue != NULL )
+                    if( pTemplate[ iAttrib ].pValue == NULL )
+                    {
+                        pTemplate[ iAttrib ].ulValueLen = sizeof( ucP256Oid );
+                    }
+                    else
                     {
                         if( pTemplate[ iAttrib ].ulValueLen < sizeof( ucP256Oid ) )
                         {

--- a/source/portable/mbedtls/iot_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/iot_pkcs11_mbedtls.c
@@ -4254,7 +4254,6 @@ CK_DECLARE_FUNCTION( CK_RV, C_Verify )( CK_SESSION_HANDLE hSession,
         else
         {
             LogError( ( "Failed verify operation. Received an unexpected mechanism." ) );
-            xResult = CKR_TEMPLATE_INCONSISTENT;
         }
     }
 

--- a/source/portable/mbedtls/iot_pkcs11_mbedtls.c
+++ b/source/portable/mbedtls/iot_pkcs11_mbedtls.c
@@ -2849,6 +2849,7 @@ CK_DECLARE_FUNCTION( CK_RV, C_GetAttributeValue )( CK_SESSION_HANDLE hSession,
                     break;
 
                 case CKA_EC_PARAMS:
+
                     if( pTemplate[ iAttrib ].pValue == NULL )
                     {
                         pTemplate[ iAttrib ].ulValueLen = sizeof( ucP256Oid );

--- a/test/unit-test/iot_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/iot_pkcs11_mbedtls_utest.c
@@ -912,6 +912,30 @@ void test_pkcs11_C_OpenSessionBadArgs( void )
     TEST_ASSERT_EQUAL( CKR_OK, xResult );
 }
 
+/*!
+ * @brief C_OpenSession Unable to acquire mutex.
+ *
+ */
+void test_pkcs11_C_OpenSession_UnaquiredMutex( void )
+{
+    CK_RV xResult = CKR_OK;
+    CK_SESSION_HANDLE xSession = 0;
+    CK_FLAGS xFlags = CKF_SERIAL_SESSION | CKF_RW_SESSION;
+
+    xResult = prvInitializePkcs11();
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+    if( TEST_PROTECT() )
+    {
+        mock_osal_calloc_Stub( pvPkcs11CallocCb );
+        mock_osal_mutex_lock_ExpectAnyArgsAndReturn( 1 );
+        xResult = C_OpenSession( 0, xFlags, NULL, 0, &xSession );
+        TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+    }
+
+    xResult = prvUninitializePkcs11();
+    TEST_ASSERT_EQUAL( CKR_OK, xResult );
+}
 /* ======================  TESTING C_CloseSession  ============================ */
 
 /*!

--- a/test/unit-test/iot_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/iot_pkcs11_mbedtls_utest.c
@@ -2160,6 +2160,14 @@ void test_pkcs11_C_FindObjectsInitBadArgs( void )
         xResult = C_FindObjectsInit( xSession, ( CK_ATTRIBUTE_PTR ) &xFindTemplate, -1 );
         TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
 
+
+        mock_osal_calloc_Stub( NULL );
+        mock_osal_calloc_ExpectAnyArgsAndReturn( NULL );
+        xResult = C_FindObjectsInit( xSession, (CK_ATTRIBUTE_PTR ) &xFindTemplate, ulCount);
+        mock_osal_calloc_Stub( pvPkcs11CallocCb );
+        TEST_ASSERT_EQUAL( CKR_HOST_MEMORY, xResult );
+
+
         /* Clean up after C_FindObjectsInit. */
         xResult = C_FindObjectsFinal( xSession );
         TEST_ASSERT_EQUAL( CKR_OPERATION_NOT_INITIALIZED, xResult );
@@ -2263,6 +2271,9 @@ void test_pkcs11_C_FindObjectsBadArgs( void )
 
         xResult = C_FindObjectsFinal( xSession );
         TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        xResult = C_FindObjects( xSession, ( CK_ATTRIBUTE_PTR ) &xObject, 0, &ulFoundCount );
+        TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -2542,6 +2553,20 @@ void test_pkcs11_C_DigestFinalBadArgs( void )
         xResult = C_DigestFinal( xSession, pxDummyData, &ulDigestLen );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
         TEST_ASSERT_EQUAL( pkcs11SHA256_DIGEST_LENGTH, ulDigestLen );
+
+        mbedtls_sha256_finish_ret_IgnoreAndReturn( -1 );
+        xResult = C_DigestFinal( xSession, pxDummyData, NULL );
+        TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+
+
+        mbedtls_sha256_init_CMockIgnore();
+        mbedtls_sha256_starts_ret_IgnoreAndReturn( 0 );
+        xResult = C_DigestInit( xSession, &xMechanism );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        ulDigestLen = 0;
+        xResult = C_DigestFinal( xSession, pxDummyData, &ulDigestLen );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -2794,6 +2819,24 @@ void test_pkcs11_C_SignInitECDSABadArgs( void )
         PKCS11_PAL_GetObjectValue_ReturnThruPtr_pIsPrivate( &xIsPrivate );
         xResult = C_SignInit( xSession, &xMechanism, xObject );
         TEST_ASSERT_EQUAL( CKR_KEY_TYPE_INCONSISTENT, xResult );
+
+        PKCS11_PAL_GetObjectValue_ExpectAnyArgsAndReturn( CKR_OK );
+        mock_osal_mutex_lock_ExpectAnyArgsAndReturn( -1 );
+        xResult = C_SignInit( xSession, &xMechanism, xObject );
+        mock_osal_mutex_lock_IgnoreAndReturn( 0 );
+        TEST_ASSERT_EQUAL( CKR_CANT_LOCK, xResult );
+
+        PKCS11_PAL_GetObjectValue_IgnoreAndReturn( CKR_OK );
+        mbedtls_pk_free_CMockIgnore();
+        mbedtls_pk_init_CMockIgnore();
+        mbedtls_pk_parse_key_IgnoreAndReturn( 0 );
+        PKCS11_PAL_GetObjectValueCleanup_CMockIgnore();
+        mbedtls_pk_get_type_IgnoreAndReturn( MBEDTLS_PK_ECDSA );
+        xResult = C_SignInit( xSession, &xMechanism, xObject );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        xResult = C_SignInit( xSession, &xMechanism, xObject );
+        TEST_ASSERT_EQUAL( CKR_OPERATION_ACTIVE, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -2959,6 +3002,29 @@ void test_pkcs11_C_SignBadArgs( void )
         PKI_mbedTLSSignatureToPkcs11Signature_IgnoreAndReturn( -1 );
         xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
         TEST_ASSERT_EQUAL( CKR_FUNCTION_FAILED, xResult );
+
+        xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, NULL );
+        TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+
+        xResult = C_SignInit( xSession, &xMechanism, xKey );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        ulDummySignatureLen = 0;
+        xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
+        TEST_ASSERT_EQUAL( CKR_BUFFER_TOO_SMALL, xResult );
+
+        ulDummySignatureLen = sizeof( pxDummySignature );
+        xResult = C_Sign( xSession, pxDummyData, 0, pxDummySignature, &ulDummySignatureLen );
+        TEST_ASSERT_EQUAL( CKR_DATA_LEN_RANGE, xResult );
+
+        xResult = C_SignInit( xSession, &xMechanism, xKey );
+        TEST_ASSERT_EQUAL( CKR_OK, xResult );
+
+        ulDummySignatureLen = sizeof( pxDummySignature );
+        mock_osal_mutex_lock_Stub( NULL );
+        mock_osal_mutex_lock_ExpectAnyArgsAndReturn( -1 );
+        xResult = C_Sign( xSession, pxDummyData, ulDummyDataLen, pxDummySignature, &ulDummySignatureLen );
+        TEST_ASSERT_EQUAL( CKR_CANT_LOCK, xResult );
     }
 
     prvCommonDeinitStubs();
@@ -3923,6 +3989,22 @@ void test_pkcs11_C_GenerateKeyPairBadArgs( void )
                                      NULL, sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
                                      &xPubKeyHandle, &xPrivKeyHandle );
         TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
+
+        xPrivateKeyTemplate[ 0 ].type = CKA_LABEL + CKA_KEY_TYPE + CKA_SIGN + CKA_PRIVATE + CKA_TOKEN;
+        xResult = C_GenerateKeyPair( xSession, &xMechanism, xPublicKeyTemplate,
+                                     sizeof( xPublicKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                     xPrivateKeyTemplate, sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                     &xPubKeyHandle, &xPrivKeyHandle );
+        TEST_ASSERT_EQUAL( CKR_ATTRIBUTE_TYPE_INVALID, xResult );
+
+        xPrivateKeyTemplate[ 0 ].type = CKA_KEY_TYPE;
+        xPublicKeyTemplate[ 0 ].type = CKA_LABEL + CKA_KEY_TYPE + CKA_EC_PARAMS + CKA_VERIFY + CKA_TOKEN;
+        xResult = C_GenerateKeyPair( xSession, &xMechanism, xPublicKeyTemplate,
+                                     sizeof( xPublicKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                     xPrivateKeyTemplate, sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
+                                     &xPubKeyHandle, &xPrivKeyHandle );
+        TEST_ASSERT_EQUAL( CKR_TEMPLATE_INCONSISTENT, xResult );
+
     }
 
     prvCommonDeinitStubs();

--- a/test/unit-test/iot_pkcs11_mbedtls_utest.c
+++ b/test/unit-test/iot_pkcs11_mbedtls_utest.c
@@ -1185,8 +1185,6 @@ void test_pkcs11_C_CreateObjectECPrivKeyBadAtt( void )
                                   sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
                                   &xObject );
         TEST_ASSERT_EQUAL( CKR_ARGUMENTS_BAD, xResult );
-
-
     }
 
     prvCommonDeinitStubs();
@@ -2052,7 +2050,6 @@ void test_pkcs11_C_GetAttributeBadArgs( void )
 
         xResult = C_GetAttributeValue( xSession, pkcs11configMAX_NUM_OBJECTS + 2, ( CK_ATTRIBUTE_PTR ) &xResult, ulCount );
         TEST_ASSERT_EQUAL( CKR_OBJECT_HANDLE_INVALID, xResult );
-
     }
 
     prvCommonDeinitStubs();
@@ -2163,7 +2160,7 @@ void test_pkcs11_C_FindObjectsInitBadArgs( void )
 
         mock_osal_calloc_Stub( NULL );
         mock_osal_calloc_ExpectAnyArgsAndReturn( NULL );
-        xResult = C_FindObjectsInit( xSession, (CK_ATTRIBUTE_PTR ) &xFindTemplate, ulCount);
+        xResult = C_FindObjectsInit( xSession, ( CK_ATTRIBUTE_PTR ) &xFindTemplate, ulCount );
         mock_osal_calloc_Stub( pvPkcs11CallocCb );
         TEST_ASSERT_EQUAL( CKR_HOST_MEMORY, xResult );
 
@@ -4004,7 +4001,6 @@ void test_pkcs11_C_GenerateKeyPairBadArgs( void )
                                      xPrivateKeyTemplate, sizeof( xPrivateKeyTemplate ) / sizeof( CK_ATTRIBUTE ),
                                      &xPubKeyHandle, &xPrivKeyHandle );
         TEST_ASSERT_EQUAL( CKR_TEMPLATE_INCONSISTENT, xResult );
-
     }
 
     prvCommonDeinitStubs();


### PR DESCRIPTION
Bump `iot_pcks11_mbedtls.c` to 97.3% line coverage.

`CKA_EC_PARAMS` attribute size can now be queried by passing `pValue = NULL`